### PR TITLE
fix autocomplete="off" in google-chrome

### DIFF
--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -69,7 +69,7 @@ class Autocomplete {
     this.root.style.position = 'relative'
 
     this.input.setAttribute('role', 'combobox')
-    this.input.setAttribute('autocomplete', 'off')
+    this.input.setAttribute('autocomplete', 'user-password')
     this.input.setAttribute('autocapitalize', 'off')
     this.input.setAttribute('autocorrect', 'off')
     this.input.setAttribute('spellcheck', 'false')

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -69,7 +69,7 @@ class Autocomplete {
     this.root.style.position = 'relative'
 
     this.input.setAttribute('role', 'combobox')
-    this.input.setAttribute('autocomplete', 'user-password')
+    this.input.setAttribute('autocomplete', 'disabled-autocomplete')
     this.input.setAttribute('autocapitalize', 'off')
     this.input.setAttribute('autocorrect', 'off')
     this.input.setAttribute('spellcheck', 'false')

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -108,7 +108,7 @@ export default {
         class: `${this.baseClass}-input`,
         value: this.value,
         role: 'combobox',
-        autocomplete: 'user-password',
+        autocomplete: 'disabled-autocomplete',
         autocapitalize: 'off',
         autocorrect: 'off',
         spellcheck: 'false',

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -108,7 +108,7 @@ export default {
         class: `${this.baseClass}-input`,
         value: this.value,
         role: 'combobox',
-        autocomplete: 'off',
+        autocomplete: 'user-password',
         autocapitalize: 'off',
         autocorrect: 'off',
         spellcheck: 'false',


### PR DESCRIPTION
I change autocomplete value of input from off to user-password to force google-chrome ignore this field.

Last versions of google-chrome ignore the attribute `autocomplete="off"` or `autocomplete="false"` when the feature **save and fill addresses** is enable

More information [here](https://www.helplazy.com/blog/what-to-do-when-chrome-ignores-autocompleteoff-on-your-form)