### PR TITLE
Propogate the onUpdate event for the Vue component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.2.0 (May 28, 2020)
+
+### autocomplete-vue
+
+- Added `update` event when the results list is updated (Ben Roth, [@ben-roth-](https://github.com/ben-roth-))
+
+### autocomplete-js
+
+- Added `onUpdate` event when the results list is updated (Ben Roth, [@ben-roth-](https://github.com/ben-roth-))
+
 ## v2.1.1 (February 24, 2020)
 
 - Updated storybook to v5.3. Updated stories to new format.

--- a/docs/javascript-component.md
+++ b/docs/javascript-component.md
@@ -86,6 +86,7 @@ Note that if using a selector, it's expected that the selector only matches one 
 | :---------------------------------- | :------------------ | :--------------- | :------------------------------------------------------------------------------------------------------ |
 | [`search`](#search)                 | Function (required) |                  | The search function to be executed on user input. Can be a synchronous function or a `Promise`.         |
 | [`onSubmit`](#onsubmit)             | Function            |                  | Executed on input submission                                                                            |
+| [`onUpdate`](#onupdate)             | Function            |                  | Executed when the results list is updated                                                               |
 | [`baseClass`](#baseclass)           | String              | `'autocomplete'` | Base class used to create classes and IDs for generated DOM elements                                    |
 | [`autoSelect`](#autoselect)         | Boolean             | `false`          | Controls whether first result should be highlighted after input                                         |
 | [`getResultValue`](#getresultvalue) | Function            |                  | For complex search results, this function is executed to get the value to display in the input          |
@@ -120,6 +121,30 @@ The `onSubmit` function is executed when the user submits their result by either
   See the Pen <a href='https://codepen.io/trevoreyre/pen/MLBNBp/'>Autocomplete onSubmit option - @trevoreyre/autocomplete-js</a> by Trevor Eyre
   (<a href='https://codepen.io/trevoreyre'>@trevoreyre</a>) on <a href='https://codepen.io'>CodePen</a>.
 </iframe>
+
+#### onUpdate
+
+The `onUpdate` function is executed when the results list is updated. The function receives the results list and the index of the selected result.
+
+```js
+new Autocomplete('#autocomplete', {
+  search: input => {
+    if (input.length < 1) {
+      return []
+    }
+    return countries.filter(country => {
+      return country.toLowerCase().startsWith(input.toLowerCase())
+    })
+  },
+
+  onUpdate: (results, selectedIndex) => {
+    console.log(`${results.length} results`)
+    if (selectedIndex > -1) {
+      console.log(`Selected: ${results[selectedIndex]}`)
+    }
+  },
+})
+```
 
 #### baseClass
 

--- a/docs/vue-component.md
+++ b/docs/vue-component.md
@@ -75,9 +75,10 @@ See the example below to see it in action.
 
 ## Events
 
-| Event               | Signature                      | Description                  |
-| :------------------ | :----------------------------- | :--------------------------- |
-| [`submit`](#submit) | `function (result: any): void` | Executed on input submission |
+| Event               | Signature                                                | Description                               |
+| :------------------ | :------------------------------------------------------- | :---------------------------------------- |
+| [`submit`](#submit) | `function (result: any): void`                           | Executed on input submission              |
+| [`update`](#update) | `function (results: any[], selectedIndex: Number): void` | Executed when the results list is updated |
 
 #### search
 
@@ -171,6 +172,19 @@ The `submit` event is executed when the user submits their result by either sele
   See the Pen <a href='https://codepen.io/trevoreyre/pen/ErBowo/'>Autocomplete onSubmit prop - @trevoreyre/autocomplete-vue</a> by Trevor Eyre
   (<a href='https://codepen.io/trevoreyre'>@trevoreyre</a>) on <a href='https://codepen.io'>CodePen</a>.
 </iframe>
+
+#### update
+
+The `update` event is executed when the results list is updated. The function receives the results list and the index of the selected result.
+
+```js
+update(results, selectedIndex) {
+  console.log(`${results.length} results`)
+  if (selectedIndex > -1) {
+    console.log(`Selected: ${results[selectedIndex]}`)
+  }
+}
+```
 
 ## Slots
 

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -35,6 +35,7 @@ class Autocomplete {
     {
       search,
       onSubmit = () => {},
+      onUpdate,
       baseClass = 'autocomplete',
       autoSelect,
       getResultValue = result => result,
@@ -47,6 +48,7 @@ class Autocomplete {
     this.resultList = this.root.querySelector('ul')
     this.baseClass = baseClass
     this.getResultValue = getResultValue
+    this.onUpdate = onUpdate
     if (typeof renderResult === 'function') {
       this.renderResult = renderResult
     }
@@ -143,6 +145,10 @@ class Autocomplete {
       this.updateStyle()
     }
     this.core.checkSelectedResultVisible(this.resultList)
+
+    if (this.onUpdate && typeof this.onUpdate === 'function') {
+      this.onUpdate(results, selectedIndex)
+    }
   }
 
   handleShow = () => {

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -35,7 +35,7 @@ class Autocomplete {
     {
       search,
       onSubmit = () => {},
-      onUpdate,
+      onUpdate = () => {},
       baseClass = 'autocomplete',
       autoSelect,
       getResultValue = result => result,
@@ -145,10 +145,7 @@ class Autocomplete {
       this.updateStyle()
     }
     this.core.checkSelectedResultVisible(this.resultList)
-
-    if (this.onUpdate && typeof this.onUpdate === 'function') {
-      this.onUpdate(results, selectedIndex)
-    }
+    this.onUpdate(results, selectedIndex)
   }
 
   handleShow = () => {

--- a/packages/autocomplete-js/Autocomplete.stories.js
+++ b/packages/autocomplete-js/Autocomplete.stories.js
@@ -133,6 +133,28 @@ export const SubmitEvent = () => {
   return root
 }
 
+export const UpdateEvent = () => {
+  const root = createRoot()
+  root.innerHTML = `
+    <input
+      class='autocomplete-input'
+      placeholder='Search for a country'
+      aria-label='Search for a country'
+    >
+    <ul class='autocomplete-result-list'></ul>
+  `
+  new Autocomplete(root, {
+    search,
+    onUpdate: (results, selectedIndex) => {
+      return action('update')(
+        `${results.length} results`,
+        `Selected: ${results[selectedIndex] || 'NA'}`
+      )
+    },
+  })
+  return root
+}
+
 export const CustomClass = () => {
   const root = createRoot()
   root.classList.add('search')

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -210,10 +210,9 @@ new Autocomplete('#autocomplete', {
   },
 
   onUpdate: (results, selectedIndex) => {
+    console.log(`${results.length} results`)
     if (selectedIndex > -1) {
-      console.log(`The currently selected result is ${results[selectedIndex]}`)
-    } else {
-      console.log(`No results currently selected`);
+      console.log(`Selected: ${results[selectedIndex]}`)
     }
   },
 })

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -99,6 +99,7 @@ elements.forEach(el => {
 | :---------------------------------- | :------------------ | :--------------- | :------------------------------------------------------------------------------------------------------ |
 | [`search`](#search)                 | Function (required) |                  | The search function to be executed on user input. Can be a synchronous function or a `Promise`.         |
 | [`onSubmit`](#onsubmit)             | Function            |                  | Executed on input submission                                                                            |
+| [`onUpdate`](#onupdate)             | Function            |                  | Executed when the results list is updated                                                               |
 | [`baseClass`](#baseclass)           | String              | `'autocomplete'` | Base class used to create classes and IDs for generated DOM elements                                    |
 | [`autoSelect`](#autoselect)         | Boolean             | `false`          | Controls whether first result should be highlighted after input                                         |
 | [`getResultValue`](#getresultvalue) | Function            |                  | For complex search results, this function is executed to get the value to display in the input          |
@@ -189,6 +190,31 @@ new Autocomplete('#autocomplete', {
 
   onSubmit: result => {
     alert(`You selected ${result}`)
+  },
+})
+```
+
+#### onUpdate
+
+The `onUpdate` function is executed when the results list is updated. The function receives the results list and the index of the selected result.
+
+```js
+new Autocomplete('#autocomplete', {
+  search: input => {
+    if (input.length < 1) {
+      return []
+    }
+    return countries.filter(country => {
+      return country.toLowerCase().startsWith(input.toLowerCase())
+    })
+  },
+
+  onUpdate: (results, selectedIndex) => {
+    if (selectedIndex > -1) {
+      console.log(`The currently selected result is ${results[selectedIndex]}`)
+    } else {
+      console.log(`No results currently selected`);
+    }
   },
 })
 ```

--- a/packages/autocomplete-vue/Autocomplete.stories.js
+++ b/packages/autocomplete-vue/Autocomplete.stories.js
@@ -157,6 +157,26 @@ export const SubmitEvent = () => ({
   },
 })
 
+export const UpdateEvent = () => ({
+  template: `
+    <Autocomplete
+      aria-label="Search for a country"
+      placeholder="Search for a country"
+      :search="search"
+      @update="onUpdate"
+    />
+  `,
+  methods: {
+    search,
+    onUpdate(results, selectedIndex) {
+      return action('update')(
+        `${results.length} results`,
+        `Selected: ${results[selectedIndex] || 'NA'}`
+      )
+    },
+  },
+})
+
 export const CustomClass = () => ({
   template: `
     <Autocomplete

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -204,6 +204,7 @@ export default {
     handleUpdate(results, selectedIndex) {
       this.results = results
       this.selectedIndex = selectedIndex
+      this.$emit('update', results, selectedIndex)
     },
 
     handleShow() {

--- a/packages/autocomplete-vue/README.md
+++ b/packages/autocomplete-vue/README.md
@@ -75,6 +75,7 @@ Then, use the component in your app.
 | Event               | Signature                      | Description                  |
 | :------------------ | :----------------------------- | :--------------------------- |
 | [`submit`](#submit) | `function (result: any): void` | Executed on input submission |
+| [`update`](#update) | `function (results: Array, selectedIndex: Number): void` | Executed when results list is updated |
 
 #### search
 
@@ -240,6 +241,20 @@ The `submit` event is executed when the user submits their result by either sele
 ```js
 submit(result) {
   alert(`You selected ${result}`)
+}
+```
+
+#### update
+
+The `update` event is executed when the results list is updated. The function receives the results list and the index of the selected result.
+
+```js
+update(results, selectedIndex) {
+  if (selectedIndex > -1) {
+    alert(`The currently selected result is ${results[selectedIndex]}`)
+  } else {
+    alert(`No results currently selected`);
+  }
 }
 ```
 

--- a/packages/autocomplete-vue/README.md
+++ b/packages/autocomplete-vue/README.md
@@ -72,10 +72,10 @@ Then, use the component in your app.
 
 ## Events
 
-| Event               | Signature                      | Description                  |
-| :------------------ | :----------------------------- | :--------------------------- |
-| [`submit`](#submit) | `function (result: any): void` | Executed on input submission |
-| [`update`](#update) | `function (results: Array, selectedIndex: Number): void` | Executed when results list is updated |
+| Event               | Signature                                                | Description                               |
+| :------------------ | :------------------------------------------------------- | :---------------------------------------- |
+| [`submit`](#submit) | `function (result: any): void`                           | Executed on input submission              |
+| [`update`](#update) | `function (results: any[], selectedIndex: Number): void` | Executed when the results list is updated |
 
 #### search
 
@@ -126,14 +126,14 @@ new Vue({
     search(input) {
       const url = `${wikiUrl}/w/api.php?${params}&srsearch=${encodeURI(input)}`
 
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         if (input.length < 3) {
           return resolve([])
         }
 
         fetch(url)
-          .then(response => response.json())
-          .then(data => {
+          .then((response) => response.json())
+          .then((data) => {
             resolve(data.query.search)
           })
       })
@@ -250,10 +250,9 @@ The `update` event is executed when the results list is updated. The function re
 
 ```js
 update(results, selectedIndex) {
+  console.log(`${results.length} results`)
   if (selectedIndex > -1) {
-    alert(`The currently selected result is ${results[selectedIndex]}`)
-  } else {
-    alert(`No results currently selected`);
+    console.log(`Selected: ${results[selectedIndex]}`)
   }
 }
 ```

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -57,6 +57,7 @@ class AutocompleteCore {
       }
       case 'Tab': {
         this.selectResult()
+        event.preventDefault()
         break
       }
       case 'Enter': {

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -57,7 +57,6 @@ class AutocompleteCore {
       }
       case 'Tab': {
         this.selectResult()
-        event.preventDefault()
         break
       }
       case 'Enter': {


### PR DESCRIPTION
I have a use case where the final input result is not one of the options in the list, but it's important to know which of those options was the selected option as the user was typing (the use case is filtering -- the user might type "Name" and see results like "Name contains" or "Name starts with," but the meaningful input won't be those results alone, and instead would be something like "Name contains Bob"). This works fine with the `submit` event as long as the user clicks an option or presses enter/return, but when the user types the entire phrase, then it is difficult to detect what the selected autocomplete option is. By propagating the `onUpdate` event, in combination with the `autoSelect` prop, I can detect what the user's desired autocomplete selection is even when they don't click the result or press enter/return.

I took a stab at updating the documentation, but I don't contribute to many projects so I'm not super familiar with best practices and procedures around all that, so please let me know if you'd need any more updates before merging this.