### PR TITLE
Force render when input change for highlighting results

### DIFF
--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -26,7 +26,7 @@
         >
           <template v-for="(result, index) in results">
             <slot name="result" :result="result" :props="resultProps[index]">
-              <li :key="resultProps[index].id" v-bind="resultProps[index]">
+              <li :key="inputProps.value + ':' + resultProps[index].id" v-bind="resultProps[index]">
                 {{ getResultValue(result) }}
               </li>
             </slot>


### PR DESCRIPTION
If I want to implement highlighting with this code, the `v-html` is not updated, because the parent list `:key` doesn't include the input:

```vue
 <autocomplete
    :value="searchInput"
  >
    <template #result="{ result, props }">
      <li v-bind="props">
        <div v-html="getHighlightedMarkup(result.value, searchInput)"></div>
      </li>
    </template>
  </autocomplete>
```

```ts
export const getHighlightedMarkup = (words, query) => {
  var regex = new RegExp(query, "ig");
  return words.toString().replace(regex, (matchedText) => {
    return `<b class="autocomplete-highlight">${matchedText}</b>`;
  });
};
```

So I've added this tiny modification on my pull request:
```vue
<li :key="inputProps.value + ':' + resultProps[index].id" v-bind="resultProps[index]">
```