### PR TITLE
WCAG: auto-select suggestion not applied when focus lost

### DIFF
--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -149,6 +149,10 @@ class AutocompleteCore {
   }
 
   hideResults = () => {
+    const selectedResult = this.results[this.selectedIndex]
+    if (this.autoSelect && selectedResult) {
+      this.setValue(selectedResult)
+    }
     this.selectedIndex = -1
     this.results = []
     this.setAttribute('aria-expanded', false)


### PR DESCRIPTION
> List autocomplete with automatic selection: When the popup is triggered, it presents suggested values that complete or logically correspond to the characters typed in the textbox, and the first suggestion is automatically highlighted as selected. **The automatically selected suggestion becomes the value of the textbox when the combobox loses focus unless the user chooses a different suggestion or changes the character string in the textbox.**

https://www.w3.org/TR/wai-aria-practices/#combobox