### PR TITLE
prevent unexpected context switch

### DIFF
--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -34,6 +34,7 @@ class Autocomplete {
     root,
     {
       search,
+      preventContextSwitch = false,
       onSubmit = () => {},
       onUpdate = () => {},
       baseClass = 'autocomplete',
@@ -49,6 +50,7 @@ class Autocomplete {
     this.baseClass = baseClass
     this.getResultValue = getResultValue
     this.onUpdate = onUpdate
+    this.preventContextSwitch = preventContextSwitch
     if (typeof renderResult === 'function') {
       this.renderResult = renderResult
     }
@@ -56,6 +58,8 @@ class Autocomplete {
     const core = new AutocompleteCore({
       search,
       autoSelect,
+      preventContextSwitch: this.preventContextSwitch,
+      expanded: this.expanded,
       setValue: this.setValue,
       setAttribute: this.setAttribute,
       onUpdate: this.handleUpdate,
@@ -103,6 +107,13 @@ class Autocomplete {
     this.input.addEventListener('keydown', this.core.handleKeyDown)
     this.input.addEventListener('focus', this.core.handleFocus)
     this.input.addEventListener('blur', this.core.handleBlur)
+    if (this.preventContextSwitch && this.input.form) {
+      this.input.addEventListener(
+        'toggle-expanded',
+        this.core.handleToggleExpanded
+      )
+      this.input.form.addEventListener('submit', this.core.handleSubmit)
+    }
     this.resultList.addEventListener(
       'mousedown',
       this.core.handleResultMouseDown
@@ -149,12 +160,20 @@ class Autocomplete {
   }
 
   handleShow = () => {
+    const prevExpandedState = this.expanded
     this.expanded = true
+    if (this.preventContextSwitch) {
+      this.dispatchExpandedState(prevExpandedState)
+    }
     this.updateStyle()
   }
 
   handleHide = () => {
+    const prevExpandedState = this.expanded
     this.expanded = false
+    if (this.preventContextSwitch) {
+      this.dispatchExpandedState(prevExpandedState)
+    }
     this.resetPosition = true
     this.updateStyle()
   }
@@ -174,6 +193,16 @@ class Autocomplete {
       return
     }
     this.core.hideResults()
+  }
+
+  dispatchExpandedState = prevExpandedState => {
+    if (prevExpandedState !== this.expanded) {
+      this.input.dispatchEvent(
+        new CustomEvent('toggle-expanded', {
+          detail: { expanded: this.expanded },
+        })
+      )
+    }
   }
 
   updateStyle = () => {

--- a/packages/autocomplete-js/Autocomplete.stories.js
+++ b/packages/autocomplete-js/Autocomplete.stories.js
@@ -202,6 +202,22 @@ export const AutoSelect = () => {
   return root
 }
 
+export const PreventContextSwitch = () => {
+  const root = createRoot()
+  root.innerHTML = `
+    <form>
+      <input
+        class='autocomplete-input'
+        placeholder='Search for a country'
+        aria-label='Search for a country'
+      >
+      <ul class='autocomplete-result-list'></ul>
+    </form>
+  `
+  new Autocomplete(root, { search, preventContextSwitch: true })
+  return root
+}
+
 export const DefaultValue = () => {
   const root = createRoot()
   root.innerHTML = `

--- a/packages/autocomplete-vue/Autocomplete.stories.js
+++ b/packages/autocomplete-vue/Autocomplete.stories.js
@@ -226,6 +226,23 @@ export const AutoSelect = () => ({
   },
 })
 
+export const PreventContextSwitch = () => ({
+  template: `
+    <form>
+      <Autocomplete
+        aria-label="Search for a country"
+        placeholder="Search for a country"
+        :search="search"
+        auto-select
+        prevent-context-switch
+      />
+    </form>
+  `,
+  methods: {
+    search,
+  },
+})
+
 export const DefaultValue = () => ({
   template: `
     <Autocomplete

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -9,6 +9,8 @@ class AutocompleteCore {
 
   constructor({
     search,
+    preventContextSwitch,
+    expanded,
     autoSelect = false,
     setValue = () => {},
     setAttribute = () => {},
@@ -22,6 +24,8 @@ class AutocompleteCore {
     this.search = isPromise(search)
       ? search
       : value => Promise.resolve(search(value))
+    this.preventContextSwitch = preventContextSwitch
+    this.expanded = expanded
     this.autoSelect = autoSelect
     this.setValue = setValue
     this.setAttribute = setAttribute
@@ -114,12 +118,26 @@ class AutocompleteCore {
     this.onUpdate(this.results, this.selectedIndex)
   }
 
+  handleToggleExpanded = event => {
+    this.expanded = event.detail.expanded
+  }
+
+  handleSubmit = event => {
+    if (this.expanded) {
+      event.preventDefault()
+      this.hideResults()
+    }
+  }
+
   selectResult = () => {
     const selectedResult = this.results[this.selectedIndex]
     if (selectedResult) {
       this.setValue(selectedResult)
     }
-    this.hideResults()
+
+    if (!this.preventContextSwitch) {
+      this.hideResults()
+    }
   }
 
   updateResults = value => {


### PR DESCRIPTION
I am not really advanced in vue, so any suggestions are welcome.

> Enter: **If an autocomplete suggestion is automatically selected, accepts the suggestion either by placing the input cursor at the end of the accepted value in the textbox or by performing a default action on the value.** For example, in a messaging application, the default action may be to add the accepted value to a list of message recipients and then clear the textbox so the user can add another recipient.

https://www.w3.org/TR/wai-aria-practices/#combobox
https://testen.bitv-test.de/index.php?a=di&iid=95&s=n