### PR TITLE
Dirty fix to prevent excessive events in Vue

### DIFF
--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -149,6 +149,10 @@ class AutocompleteCore {
   }
 
   hideResults = () => {
+    if (this.selectedIndex === -1 && this.results.length === 0) {
+      return
+    }
+    
     this.selectedIndex = -1
     this.results = []
     this.setAttribute('aria-expanded', false)


### PR DESCRIPTION
Hi,

This is a somewhat dirty fix to prevent excessive events in the Vue component. Currently, on every single click on the page, each Autocomplete component on the page will emit an "Update" event.

Eg. I have 4 Autocomplete components on my page, whenever I click to focus another, regular, input - each of the Autocomplete components fire an Update event.