### PR TITLE
Update AutocompleteCore.js - Tab key also fires onSubmit

### DIFF
--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -55,10 +55,7 @@ class AutocompleteCore {
         this.handleArrows(selectedIndex)
         break
       }
-      case 'Tab': {
-        this.selectResult()
-        break
-      }
+      case 'Tab':
       case 'Enter': {
         const selectedResult = this.results[this.selectedIndex]
         this.selectResult()


### PR DESCRIPTION
If I want to select a result with the keyboard when the autocomplete element appears in the context of a <form>, pressing Enter to select it is undesirable, as the browser will try to submit the whole form; selecting from the list with Tab would be the idiomatic alternative, and this updates the input field as expected - but does not currently fire onSubmit as pressing Enter does, which means I can't as easily validate the selection/propagate the selected result. I have found that this small modification saves a lot of bother!