### PR TITLE
add destroy method Fixes #22

### DIFF
--- a/docs/javascript-component.md
+++ b/docs/javascript-component.md
@@ -222,9 +222,9 @@ The `renderResult` function should return either a DOM element or an HTML string
 
 ## Methods
 
-| Name      |  Description                                                                             |
-| :-------- | :--------------------------------------------------------------------------------------- |
-| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |
+| Name      | Description                                                                            |
+|-----------|----------------------------------------------------------------------------------------|
+| `destroy` | Removes all event listeners and object references that were set during initialization. |
 
 ## Styling and customization
 

--- a/docs/javascript-component.md
+++ b/docs/javascript-component.md
@@ -223,7 +223,7 @@ The `renderResult` function should return either a DOM element or an HTML string
 ## Methods
 
 | Name      | Description                                                                            |
-|-----------|----------------------------------------------------------------------------------------|
+|:----------|:---------------------------------------------------------------------------------------|
 | `destroy` | Removes all event listeners and object references that were set during initialization. |
 
 ## Styling and customization

--- a/docs/javascript-component.md
+++ b/docs/javascript-component.md
@@ -222,9 +222,9 @@ The `renderResult` function should return either a DOM element or an HTML string
 
 ## Methods
 
-| Name  |  Description                            |
-| :-------- | :------------------------------- |
-| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |
+| Name      |  Description                                                                             |
+| :-------- | :--------------------------------------------------------------------------------------- |
+| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |
 
 ## Styling and customization
 

--- a/docs/javascript-component.md
+++ b/docs/javascript-component.md
@@ -220,6 +220,12 @@ The `renderResult` function should return either a DOM element or an HTML string
   (<a href='https://codepen.io/trevoreyre'>@trevoreyre</a>) on <a href='https://codepen.io'>CodePen</a>.
 </iframe>
 
+## Methods
+
+| Name  |  Description                            |
+| :-------- | :------------------------------- |
+| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |
+
 ## Styling and customization
 
 To include the default styling of the autocomplete component that you see here in the docs, include the CSS file on your page.

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -130,6 +130,7 @@ class Autocomplete {
     this.onUpdate = null
     this.renderResult = null
     this.core.destroy()
+    this.core = null
   }
 
   setAttribute = (attribute, value) => {

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -122,6 +122,7 @@ class Autocomplete {
       this.core.handleResultMouseDown
     )
     this.resultList.removeEventListener('click', this.core.handleResultClick)
+    this.root = null
   }
 
   setAttribute = (attribute, value) => {

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -111,6 +111,19 @@ class Autocomplete {
     this.updateStyle()
   }
 
+  destroy = () => {
+    document.body.removeEventListener('click', this.handleDocumentClick)
+    this.input.removeEventListener('input', this.core.handleInput)
+    this.input.removeEventListener('keydown', this.core.handleKeyDown)
+    this.input.removeEventListener('focus', this.core.handleFocus)
+    this.input.removeEventListener('blur', this.core.handleBlur)
+    this.resultList.removeEventListener(
+      'mousedown',
+      this.core.handleResultMouseDown
+    )
+    this.resultList.removeEventListener('click', this.core.handleResultClick)
+  }
+
   setAttribute = (attribute, value) => {
     this.input.setAttribute(attribute, value)
   }

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -122,7 +122,14 @@ class Autocomplete {
       this.core.handleResultMouseDown
     )
     this.resultList.removeEventListener('click', this.core.handleResultClick)
+
     this.root = null
+    this.input = null
+    this.resultList = null
+    this.getResultValue = null
+    this.onUpdate = null
+    this.renderResult = null
+    this.core.destroy()
   }
 
   setAttribute = (attribute, value) => {

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -382,9 +382,9 @@ new Autocomplete('#autocomplete', {
 ```
 ## Methods
 
-| Name  |  Description                            |
-| :-------- | :------------------------------- |
-| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |
+| Name      |  Description                                                                             |
+| :-------- | :--------------------------------------------------------------------------------------- |
+| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |
 
 ## Styling and customization
 

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -382,9 +382,9 @@ new Autocomplete('#autocomplete', {
 ```
 ## Methods
 
-| Name      |  Description                                                                             |
-| :-------- | :--------------------------------------------------------------------------------------- |
-| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |
+| Name      | Description                                                                            |
+|-----------|----------------------------------------------------------------------------------------|
+| `destroy` | Removes all event listeners and object references that were set during initialization. |
 
 ## Styling and customization
 

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -383,7 +383,7 @@ new Autocomplete('#autocomplete', {
 ## Methods
 
 | Name      | Description                                                                            |
-|-----------|----------------------------------------------------------------------------------------|
+|:----------|:---------------------------------------------------------------------------------------|
 | `destroy` | Removes all event listeners and object references that were set during initialization. |
 
 ## Styling and customization

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -380,6 +380,11 @@ new Autocomplete('#autocomplete', {
   },
 })
 ```
+## Methods
+
+| Name  |  Description                            |
+| :-------- | :------------------------------- |
+| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |
 
 ## Styling and customization
 

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -35,7 +35,6 @@ class AutocompleteCore {
 
   destroy = () => {
     this.search = null
-    this.autoSelect = null
     this.setValue = null
     this.setAttribute = null
     this.onUpdate = null

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -33,6 +33,19 @@ class AutocompleteCore {
     this.onLoaded = onLoaded
   }
 
+  destroy = () => {
+    this.search = null
+    this.autoSelect = null
+    this.setValue = null
+    this.setAttribute = null
+    this.onUpdate = null
+    this.onSubmit = null
+    this.onShow = null
+    this.onHide = null
+    this.onLoading = null
+    this.onLoaded = null
+  }
+
   handleInput = event => {
     const { value } = event.target
     this.updateResults(value)

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -68,6 +68,6 @@ The core package provides a number of event handlers that can be wired up in the
 
 ## Methods
 
-| Name  |  Description                            |
-| :-------- | :------------------------------- |
-| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |
+| Name      |  Description                                                                             |
+| :-------- | :--------------------------------------------------------------------------------------- |
+| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -65,3 +65,9 @@ The core package provides a number of event handlers that can be wired up in the
 
 [javascript-component]: packages/autocomplete-js/Autocomplete.js
 [vue-component]: packages/autocomplete-vue/Autocomplete.vue
+
+## Methods
+
+| Name  |  Description                            |
+| :-------- | :------------------------------- |
+| `destroy`    | Removes all event listeners and DOM node references that were set during initialization.                     |

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -69,5 +69,5 @@ The core package provides a number of event handlers that can be wired up in the
 ## Methods
 
 | Name      | Description                                                                            |
-|-----------|----------------------------------------------------------------------------------------|
+|:----------|:---------------------------------------------------------------------------------------|
 | `destroy` | Removes all event listeners and object references that were set during initialization. |

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -68,6 +68,6 @@ The core package provides a number of event handlers that can be wired up in the
 
 ## Methods
 
-| Name      |  Description                                                                             |
-| :-------- | :--------------------------------------------------------------------------------------- |
-| `destroy` | Removes all event listeners and DOM node references that were set during initialization. |
+| Name      | Description                                                                            |
+|-----------|----------------------------------------------------------------------------------------|
+| `destroy` | Removes all event listeners and object references that were set during initialization. |


### PR DESCRIPTION
Adds a destroy method that basically just removes all the listeners that were set. I don't see any dom nodes that were inserted anywhere or any other references that would need to be cleaned up, so I think this would be it. Let me know if I missed anything and I can update it.