### PR TITLE
Autocorrect option

### DIFF
--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -80,6 +80,7 @@ class Autocomplete {
     this.input.setAttribute('role', 'combobox')
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('autocapitalize', 'off')
+    this.input.setAttribute('autocorrect', 'off')
     this.input.setAttribute('spellcheck', 'false')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-haspopup', 'listbox')

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -80,7 +80,6 @@ class Autocomplete {
     this.input.setAttribute('role', 'combobox')
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('autocapitalize', 'off')
-    this.input.setAttribute('autocorrect', 'off')
     this.input.setAttribute('spellcheck', 'false')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-haspopup', 'listbox')

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -37,6 +37,7 @@ class Autocomplete {
       onSubmit = () => {},
       onUpdate = () => {},
       baseClass = 'autocomplete',
+      autocorrect = false,
       autoSelect,
       getResultValue = result => result,
       renderResult,
@@ -47,6 +48,7 @@ class Autocomplete {
     this.input = this.root.querySelector('input')
     this.resultList = this.root.querySelector('ul')
     this.baseClass = baseClass
+    this.autocorrect = autocorrect
     this.getResultValue = getResultValue
     this.onUpdate = onUpdate
     if (typeof renderResult === 'function') {
@@ -59,6 +61,7 @@ class Autocomplete {
       setValue: this.setValue,
       setAttribute: this.setAttribute,
       onUpdate: this.handleUpdate,
+      autocorrect: this.autocorrect,
       onSubmit,
       onShow: this.handleShow,
       onHide: this.handleHide,
@@ -80,7 +83,9 @@ class Autocomplete {
     this.input.setAttribute('role', 'combobox')
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('autocapitalize', 'off')
-    this.input.setAttribute('autocorrect', 'off')
+    if (this.autocorrect) {
+      this.input.setAttribute('autocorrect', 'on')
+    }
     this.input.setAttribute('spellcheck', 'false')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-haspopup', 'listbox')

--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -37,7 +37,6 @@ class Autocomplete {
       onSubmit = () => {},
       onUpdate = () => {},
       baseClass = 'autocomplete',
-      autocorrect = false,
       autoSelect,
       getResultValue = result => result,
       renderResult,
@@ -48,7 +47,6 @@ class Autocomplete {
     this.input = this.root.querySelector('input')
     this.resultList = this.root.querySelector('ul')
     this.baseClass = baseClass
-    this.autocorrect = autocorrect
     this.getResultValue = getResultValue
     this.onUpdate = onUpdate
     if (typeof renderResult === 'function') {
@@ -61,7 +59,6 @@ class Autocomplete {
       setValue: this.setValue,
       setAttribute: this.setAttribute,
       onUpdate: this.handleUpdate,
-      autocorrect: this.autocorrect,
       onSubmit,
       onShow: this.handleShow,
       onHide: this.handleHide,
@@ -83,9 +80,7 @@ class Autocomplete {
     this.input.setAttribute('role', 'combobox')
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('autocapitalize', 'off')
-    if (this.autocorrect) {
-      this.input.setAttribute('autocorrect', 'on')
-    }
+    this.input.setAttribute('autocorrect', 'off')
     this.input.setAttribute('spellcheck', 'false')
     this.input.setAttribute('aria-autocomplete', 'list')
     this.input.setAttribute('aria-haspopup', 'listbox')

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -120,7 +120,6 @@ export default {
         role: 'combobox',
         autocomplete: 'off',
         autocapitalize: 'off',
-        autocorrect: 'off',
         spellcheck: 'false',
         'aria-autocomplete': 'list',
         'aria-haspopup': 'listbox',

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -120,6 +120,7 @@ export default {
         role: 'combobox',
         autocomplete: 'off',
         autocapitalize: 'off',
+        autocorrect: 'off',
         spellcheck: 'false',
         'aria-autocomplete': 'list',
         'aria-haspopup': 'listbox',

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -15,6 +15,7 @@ class AutocompleteCore {
     onUpdate = () => {},
     onSubmit = () => {},
     onShow = () => {},
+    autocorrect = false,
     onHide = () => {},
     onLoading = () => {},
     onLoaded = () => {},
@@ -27,6 +28,7 @@ class AutocompleteCore {
     this.setAttribute = setAttribute
     this.onUpdate = onUpdate
     this.onSubmit = onSubmit
+    this.autocorrect = autocorrect
     this.onShow = onShow
     this.onHide = onHide
     this.onLoading = onLoading
@@ -39,6 +41,7 @@ class AutocompleteCore {
     this.setAttribute = null
     this.onUpdate = null
     this.onSubmit = null
+    this.autocorrect = null
     this.onShow = null
     this.onHide = null
     this.onLoading = null
@@ -148,7 +151,6 @@ class AutocompleteCore {
         this.hideResults()
         return
       }
-
       this.selectedIndex = this.autoSelect ? 0 : -1
       this.onUpdate(this.results, this.selectedIndex)
       this.showResults()

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -15,7 +15,6 @@ class AutocompleteCore {
     onUpdate = () => {},
     onSubmit = () => {},
     onShow = () => {},
-    autocorrect = false,
     onHide = () => {},
     onLoading = () => {},
     onLoaded = () => {},
@@ -28,7 +27,6 @@ class AutocompleteCore {
     this.setAttribute = setAttribute
     this.onUpdate = onUpdate
     this.onSubmit = onSubmit
-    this.autocorrect = autocorrect
     this.onShow = onShow
     this.onHide = onHide
     this.onLoading = onLoading
@@ -41,7 +39,6 @@ class AutocompleteCore {
     this.setAttribute = null
     this.onUpdate = null
     this.onSubmit = null
-    this.autocorrect = null
     this.onShow = null
     this.onHide = null
     this.onLoading = null
@@ -151,6 +148,7 @@ class AutocompleteCore {
         this.hideResults()
         return
       }
+
       this.selectedIndex = this.autoSelect ? 0 : -1
       this.onUpdate(this.results, this.selectedIndex)
       this.showResults()


### PR DESCRIPTION
We using your nice autocomplete library as well (autocomplete-js) and had exact the same w3c validation error as #88 
So i create a new option to set `autocorrect` not by default.

I dont see any Option to set `InputProps` like the autocorrect-vue, so i think this is a great way to fix this Issue.