### PR TITLE
Fix autocomplete fired again when select one item from suggestion list

### DIFF
--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -139,6 +139,10 @@ class Autocomplete {
 
   setValue = result => {
     this.input.value = result ? this.getResultValue(result) : ''
+    this.core.waitOnInput = true
+    setTimeout(() => {
+      this.core.waitOnInput = false
+    }, 500)
   }
 
   renderResult = (result, props) =>

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -6,6 +6,7 @@ class AutocompleteCore {
   searchCounter = 0
   results = []
   selectedIndex = -1
+  waitOnInput = false
 
   constructor({
     search,
@@ -47,8 +48,10 @@ class AutocompleteCore {
 
   handleInput = event => {
     const { value } = event.target
-    this.updateResults(value)
-    this.value = value
+    if (!(this.waitOnInput && this.value === value)) {
+      this.updateResults(value)
+      this.value = value
+    }
   }
 
   handleKeyDown = event => {


### PR DESCRIPTION
It happens on some recent Firefox version on Android (e.g. 99.0.1) that when we select one item from suggestion list, handleInput is triggered again with the selected value which call updateResults again. With this pull request, we use a waitOnInput property on AutocompleteCore to control updateResults triggering.