### PR TITLE
AutocompleteCore: Fix `submitOnEnter` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.4.1 (January 13, 2023)
+
+### autocomplete-core
+
+- Prevent default action (i. e. form submit) when selecting an entry from result list with <kbd>Enter</kbd> while `submitOnEnter: false` (dpxgit, [@dpxgit](https://github.com/dpxgit))
+
 ## v2.4.0 (January 9, 2023)
 
 ### autocomplete-core

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -88,7 +88,9 @@ class AutocompleteCore {
         if (this.submitOnEnter) {
           this.selectedResult && this.onSubmit(this.selectedResult)
         } else {
-          if (!isListItemSelected) {
+          if (isListItemSelected) {
+            event.preventDefault()
+          } else {
             this.selectedResult && this.onSubmit(this.selectedResult)
             this.selectedResult = null
           }


### PR DESCRIPTION
Prevent default action (i. e. form submit) when selecting an entry from result list with <kbd>Enter</kbd> while `submitOnEnter: false`