### PR TITLE
Resolved anomalous behavior of input and keydown events when typing in Korean #163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.4.2 (April 6, 2023)
+
+### autocomplete-core
+
+- Added condition statement `event.isComposing` to method `handleKeyDown`. The reason is the abnormal behavior of the input event when typing Korean. (SoonMin, [@Ssoon-m](https://github.com/Ssoon-m))
+
+### autocomplete-vue
+
+- Added a `prevValue` and changed the handleInput method. The reason is the abnormal behavior of the input event when typing Korean.
+(SoonMin, [@Ssoon-m](https://github.com/Ssoon-m))
+
 ## v2.4.1 (January 13, 2023)
 
 ### autocomplete-core

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.1",
+  "version": "2.4.2",
   "packages": [
     "packages/*"
   ],

--- a/packages/autocomplete-js/package.json
+++ b/packages/autocomplete-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trevoreyre/autocomplete-js",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simple autocomplete component in vanilla JS and Vue",
   "main": "dist/autocomplete.cjs.js",
   "module": "dist/autocomplete.esm.js",

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -103,6 +103,7 @@ export default {
     return {
       core,
       value: this.defaultValue,
+      prevValue: '',
       resultListId: uniqueId(`${this.baseClass}-result-list-`),
       results: [],
       selectedIndex: -1,
@@ -238,8 +239,12 @@ export default {
     },
 
     handleInput(event) {
-      this.value = event.target.value
-      this.core.handleInput(event)
+      const currentValue = event.target.value
+      if (currentValue !== this.prevValue) {
+        this.value = currentValue
+        this.prevValue = currentValue
+        this.core.handleInput(event)
+      }
     },
 
     handleSubmit(selectedResult) {

--- a/packages/autocomplete-vue/package.json
+++ b/packages/autocomplete-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trevoreyre/autocomplete-vue",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simple autocomplete component in vanilla JS and Vue",
   "main": "dist/autocomplete.cjs.js",
   "module": "dist/autocomplete.esm.js",

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -58,6 +58,7 @@ class AutocompleteCore {
   }
 
   handleKeyDown = event => {
+    if (event.isComposing) return
     const { key } = event
 
     switch (key) {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trevoreyre/autocomplete",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Simple autocomplete component in vanilla JS and Vue",
   "main": "dist/autocomplete.cjs.js",
   "module": "dist/autocomplete.esm.js",


### PR DESCRIPTION
- Added condition statement `event.isComposing` to method `handleKeyDown`. The reason is the abnormal behavior of the input event when typing Korean. 
- Added a `prevValue` and changed the handleInput method. The reason is the abnormal behavior of the input event when typing Korean.