### PR TITLE
Add event emitters for match count and invalid input

### DIFF
--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -217,6 +217,8 @@ export default {
     handleUpdate(results, selectedIndex) {
       this.results = results
       this.selectedIndex = selectedIndex
+      this.$emit('isvalid', this.core.isValid);
+      this.$emit('matchcount', this.core.matchCount);
       this.$emit('update', results, selectedIndex)
     },
 
@@ -240,9 +242,13 @@ export default {
     handleInput(event) {
       this.value = event.target.value
       this.core.handleInput(event)
+      this.$emit('isvalid', this.core.isValid);
+      this.$emit('matchcount', this.core.matchCount);
     },
 
     handleSubmit(selectedResult) {
+      this.$emit('isvalid', this.core.isValid);
+      this.$emit('matchcount', this.core.matchCount);
       this.$emit('submit', selectedResult)
     },
 

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -7,6 +7,8 @@ class AutocompleteCore {
   results = []
   selectedIndex = -1
   selectedResult = null
+  isValid = false
+  matched = 0
 
   constructor({
     search,
@@ -150,6 +152,9 @@ class AutocompleteCore {
     const selectedResult = this.results[this.selectedIndex]
     if (selectedResult) {
       this.setValue(selectedResult)
+      this.isValid = true;
+    } else {
+      this.isValid = false;
     }
     this.hideResults()
   }
@@ -162,9 +167,10 @@ class AutocompleteCore {
         return
       }
       this.results = results
+      this.matchCount = results.length
       this.onLoaded()
 
-      if (this.results.length === 0) {
+      if (this.matchCount === 0) {
         this.hideResults()
         return
       }


### PR DESCRIPTION
This pull request adds two properties to AutocompleteCore and two new event emitters for the vue component.

## Usecase:
I'm using Autocomplete for language selection and Address autocomplete. I need to be able to render error messages to the user if they have entered an invalid string or if they have not selected one of the valid options available to them.

Because my parent component does not know what options are available to the user, it cannot tell if the current input string is valid or not. By watching for the `isvalid` event and the `matchcount` event I can show an error message if the `matchcount` is zero and `isvalid` is false. I can also update the help text to show how many options are currently available.

With the current autocomplete implementation, the `selectedResult` only changes when a valid selection is made, but the user can enter what they like. This means that the user might have initially selected something valid then changed it to something invalid and assume that's what will be submitted to the server. In this scenario, I would like the user to know that what they've currently entered is invalid.

## Why two separate events?

This I'm less sure about. 

My reasoning is that it's better to watch for two simple event that provide distinct information that can be used independantly, rather than emitting a single event with both bits. I'm happy to change the behaviour if you would prefer a single event.

PS: Thanks for this great component. It was super easy to customise the styling and the code is beautiful and clean and easy to understand.