### PR TITLE
Play safe with old global API

### DIFF
--- a/packages/autocomplete-vue/index.js
+++ b/packages/autocomplete-vue/index.js
@@ -18,7 +18,7 @@ if (typeof window !== 'undefined') {
 } else if (typeof global !== 'undefined') {
   GlobalVue = global.Vue
 }
-if (GlobalVue) {
+if (GlobalVue && typeof GlobalVue.use === 'function') {
   GlobalVue.use(plugin)
 }
 


### PR DESCRIPTION
Vue component throws an exception when using a [CDN version of Vue 3](https://vuejs.org/guide/quick-start.html#using-vue-from-cdn).

![Screenshot from 2025-01-21 18-15-59](https://github.com/user-attachments/assets/21ea197e-472c-424f-bdf3-bc31e3ee917a)

To reproduce the issue, one can just add two scripts on the page: Vue 3 (global build) and the component itself. Here is a [demo](https://codepen.io/amphiluke/pen/ogvPqJJ?editors=0010) (open dev tools to see the exception).

The `Vue.use()` global API was removed in version 3, so a pre-check is required before calling this method. This is what the PR fixes.