### PR TITLE
Changes to submitOnEnter

### DIFF
--- a/packages/autocomplete-js/Autocomplete.js
+++ b/packages/autocomplete-js/Autocomplete.js
@@ -44,7 +44,7 @@ class Autocomplete {
       renderResult,
       debounceTime = 0,
       resultListLabel,
-      submitOnEnter = false,
+      submitOnEnter = true,
     } = {}
   ) {
     this.root = typeof root === 'string' ? document.querySelector(root) : root

--- a/packages/autocomplete-js/README.md
+++ b/packages/autocomplete-js/README.md
@@ -106,7 +106,7 @@ elements.forEach(el => {
 | [`debounceTime`](#debouncetime)       | Number              | `0`              | Time in milliseconds that the component should wait after last keystroke before calling search function |
 | [`renderResult`](#renderresult)       | Function            |                  | Override default rendering of result items                                                              |
 | [`resultListLabel`](#resultlistlabel) | String              |                  | `aria-label` or `aria-labelledby` for result list                                                       |
-| [`submitOnEnter`](#submitonenter)     | Boolean             | `false`          | Immediately call [`onSubmit`](#onsubmit) on result when pressing <kbd>Enter</kbd>                       |
+| [`submitOnEnter`](#submitonenter)     | Boolean             | `true`           | Immediately call [`onSubmit`](#onsubmit) on result when pressing <kbd>Enter</kbd>                       |
 
 #### search
 

--- a/packages/autocomplete-vue/Autocomplete.vue
+++ b/packages/autocomplete-vue/Autocomplete.vue
@@ -84,7 +84,7 @@ export default {
     },
     submitOnEnter: {
       type: Boolean,
-      default: false,
+      default: true,
     },
   },
 

--- a/packages/autocomplete-vue/README.md
+++ b/packages/autocomplete-vue/README.md
@@ -68,7 +68,7 @@ Then, use the component in your app.
 | [`defaultValue`](#defaultvalue)       | String              |                  | Initial value of the component                                                                          |
 | [`debounceTime`](#debouncetime)       | Number              | `0`              | Time in milliseconds that the component should wait after last keystroke before calling search function |
 | [`resultListLabel`](#resultlistlabel) | String              |                  | `aria-label` or `aria-labelledby` for result list                                                       |
-| [`submitOnEnter`](#submitonenter)     | Boolean             | `false`          | Immediately call [`onSubmit`](#onsubmit) on result when pressing <kbd>Enter</kbd>                       |
+| [`submitOnEnter`](#submitonenter)     | Boolean             | `true`           | Immediately call [`onSubmit`](#onsubmit) on result when pressing <kbd>Enter</kbd>                       |
 
 **Note:** Any extra props you pass will be spread on the `input` element of the autocomplete component.
 
@@ -235,7 +235,7 @@ Sets the provided string as `aria-label` on the autocomplete result list (`<ul r
 
 #### submitOnEnter
 
-If `true`, pressing <kbd>Enter</kbd> on the selected entry of the result list will pass the result immediately to the `onSubmit` function and call it. Default setting is `false`.
+If `true`, pressing <kbd>Enter</kbd> on the selected entry of the result list will pass the result immediately to the `onSubmit` function and call it. Default setting is `true`.
 
 ## Events
 

--- a/packages/autocomplete/AutocompleteCore.js
+++ b/packages/autocomplete/AutocompleteCore.js
@@ -6,7 +6,6 @@ class AutocompleteCore {
   searchCounter = 0
   results = []
   selectedIndex = -1
-  selectedResult = null
 
   constructor({
     search,
@@ -20,7 +19,7 @@ class AutocompleteCore {
     onHide = () => {},
     onLoading = () => {},
     onLoaded = () => {},
-    submitOnEnter = false,
+    submitOnEnter = true,
   } = {}) {
     this.search = isPromise(search)
       ? search
@@ -81,18 +80,16 @@ class AutocompleteCore {
         const isListItemSelected =
           event.target.getAttribute('aria-activedescendant').length > 0
 
-        this.selectedResult =
-          this.results[this.selectedIndex] || this.selectedResult
+        const selectedResult = this.results[this.selectedIndex]
         this.selectResult()
 
         if (this.submitOnEnter) {
-          this.selectedResult && this.onSubmit(this.selectedResult)
+          selectedResult && this.onSubmit(selectedResult)
         } else {
           if (isListItemSelected) {
             event.preventDefault()
           } else {
-            this.selectedResult && this.onSubmit(this.selectedResult)
-            this.selectedResult = null
+            selectedResult && this.onSubmit(selectedResult)
           }
         }
         break

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -50,7 +50,7 @@ const autocomplete = new Autocomplete(options)
 | `onHide`        | Function            | Fired when the results list is hidden                                                                          |
 | `onLoading`     | Function            | Fired if `search` is a `Promise` and hasn't resolved yet                                                       |
 | `onLoaded`      | Function            | Fired after asynchronous `search` function resolves                                                            |
-| `submitOnEnter` | Boolean             | If `true`, immediately call `onSubmit` on result when pressing <kbd>Enter</kbd>. Default: `false`              |
+| `submitOnEnter` | Boolean             | If `true`, immediately call `onSubmit` on result when pressing <kbd>Enter</kbd>. Default: `true`               |
 
 ## Event handlers
 


### PR DESCRIPTION
Changes the default value of `submitOnEnter` to `true`.  The "submit on enter" behaviour was the default prior to this option being introduced,  so it's current default of `false` made it a breaking change.  This explains issues like this one:
https://github.com/trevoreyre/autocomplete/issues/157

Also modifies the code for `submitOnEnter` so that the `selectedResult` is not saved in the class context.  

This solves an issue where the user can move focus off the input, return focus, even type some new value in the field, and when they press enter the last value stored in `selectedResult` was inputed into the field.